### PR TITLE
Flag edit for compiling in older cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 2.6)
 project(flow_solver)
-set(CMAKE_C_FLAGS "-g -Wall")
+set(CMAKE_C_FLAGS "-g -Wall --std=gnu99")
 add_executable(flow_solver flow_solver.c)


### PR DESCRIPTION
Added another flag arguement so that the code compiles in older versions of cmake with the c99 gnu option. Otherwise there will be errors for each case where a for loop has been declared like this: for(int i;...) this is not valid for older c-standards.